### PR TITLE
Add Log Service to Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
-# Install tree
-RUN apt-get update && apt-get install -y tree && rm -rf /var/lib/apt/lists/*
+# Install tree and flask for log viewer
+RUN apt-get update && apt-get install -y tree && \
+    pip install flask && \
+    rm -rf /var/lib/apt/lists/*
 
 # Copy the build scripts
 WORKDIR /
@@ -20,6 +22,9 @@ ARG APP_MANAGER_VERSION
 RUN /install_app_manager.sh
 COPY app-manager/config.json /app-manager/public/config.json
 COPY --chmod=755 app-manager/*.sh /app-manager/scripts/
+
+# Install Log Viewer
+COPY --chmod=755 log-viewer /log-viewer
 
 # Install CivitAI Model Downloader
 # ARG CIVITAI_DOWNLOADER_VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,8 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
-# Install tree and flask for log viewer
-RUN apt-get update && apt-get install -y tree && \
-    pip install flask && \
-    rm -rf /var/lib/apt/lists/*
+# Install tree
+RUN apt-get update && apt-get install -y tree && rm -rf /var/lib/apt/lists/*
 
 # Copy the build scripts
 WORKDIR /
@@ -25,6 +23,7 @@ COPY --chmod=755 app-manager/*.sh /app-manager/scripts/
 
 # Install Log Viewer
 COPY --chmod=755 log-viewer /log-viewer
+RUN /install_log_viewer.sh
 
 # Install CivitAI Model Downloader
 # ARG CIVITAI_DOWNLOADER_VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ COPY --chmod=755 app-manager/*.sh /app-manager/scripts/
 
 # Install Log Viewer
 COPY --chmod=755 log-viewer /log-viewer
+RUN /install_log_viewer.sh
 
 # Install CivitAI Model Downloader
 # ARG CIVITAI_DOWNLOADER_VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,6 @@ COPY --chmod=755 app-manager/*.sh /app-manager/scripts/
 
 # Install Log Viewer
 COPY --chmod=755 log-viewer /log-viewer
-RUN /install_log_viewer.sh
 
 # Install CivitAI Model Downloader
 # ARG CIVITAI_DOWNLOADER_VERSION

--- a/build/install_log_viewer.sh
+++ b/build/install_log_viewer.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -e
+
+echo "Installing Log Viewer dependencies..."
+
+# Use the system Python to install Flask
+python3 -m pip install flask
+
+echo "Log Viewer dependencies installed successfully!"

--- a/build/install_log_viewer.sh
+++ b/build/install_log_viewer.sh
@@ -1,9 +1,15 @@
 #!/usr/bin/env bash
 set -e
 
-echo "Installing Log Viewer dependencies..."
+echo "Installing Log Viewer with dedicated venv..."
 
-# Use the system Python to install Flask
-python3 -m pip install flask
+# Create a dedicated venv for log viewer
+python3 -m venv /log-viewer/venv
 
-echo "Log Viewer dependencies installed successfully!"
+# Activate the venv and install Flask
+source /log-viewer/venv/bin/activate
+pip install --upgrade pip
+pip install flask
+deactivate
+
+echo "Log Viewer installed successfully with its own venv!"

--- a/log-viewer/log_streamer.py
+++ b/log-viewer/log_streamer.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+import os
+import time
+from flask import Flask, Response, render_template_string
+import subprocess
+import threading
+import queue
+
+app = Flask(__name__)
+
+# HTML template with auto-scrolling and real-time updates
+HTML_TEMPLATE = '''
+<!DOCTYPE html>
+<html>
+<head>
+    <title>ComfyUI Logs</title>
+    <style>
+        body {
+            background-color: #1e1e1e;
+            color: #d4d4d4;
+            font-family: 'Consolas', 'Monaco', monospace;
+            margin: 0;
+            padding: 20px;
+        }
+        #log-container {
+            background-color: #252526;
+            border: 1px solid #3e3e42;
+            border-radius: 4px;
+            padding: 15px;
+            height: calc(100vh - 60px);
+            overflow-y: auto;
+            white-space: pre-wrap;
+            word-wrap: break-word;
+        }
+        .log-line {
+            margin: 0;
+            line-height: 1.4;
+        }
+        .error { color: #f48771; }
+        .warning { color: #dcdcaa; }
+        .info { color: #9cdcfe; }
+        .timestamp { color: #858585; }
+        h1 {
+            color: #cccccc;
+            font-size: 20px;
+            margin-bottom: 10px;
+        }
+    </style>
+</head>
+<body>
+    <h1>ComfyUI Logs - Real-time Stream</h1>
+    <div id="log-container"></div>
+
+    <script>
+        const logContainer = document.getElementById('log-container');
+        const eventSource = new EventSource('/stream');
+
+        eventSource.onmessage = function(event) {
+            const line = document.createElement('div');
+            line.className = 'log-line';
+
+            // Basic syntax highlighting
+            let text = event.data;
+            if (text.includes('ERROR') || text.includes('Error')) {
+                line.className += ' error';
+            } else if (text.includes('WARNING') || text.includes('Warning')) {
+                line.className += ' warning';
+            } else if (text.includes('INFO')) {
+                line.className += ' info';
+            }
+
+            line.textContent = text;
+            logContainer.appendChild(line);
+
+            // Auto-scroll to bottom
+            logContainer.scrollTop = logContainer.scrollHeight;
+
+            // Limit number of lines to prevent memory issues
+            while (logContainer.children.length > 1000) {
+                logContainer.removeChild(logContainer.firstChild);
+            }
+        };
+
+        eventSource.onerror = function(error) {
+            console.error('EventSource failed:', error);
+            const line = document.createElement('div');
+            line.className = 'log-line error';
+            line.textContent = '--- Connection lost, attempting to reconnect... ---';
+            logContainer.appendChild(line);
+        };
+    </script>
+</body>
+</html>
+'''
+
+def tail_file(filename, q):
+    """Tail a file and put new lines into a queue"""
+    # First, send the last 100 lines to show recent history
+    try:
+        with open(filename, 'r') as f:
+            lines = f.readlines()
+            for line in lines[-100:]:
+                q.put(line.rstrip())
+    except:
+        q.put("Waiting for ComfyUI to start...")
+
+    # Then follow the file for new content
+    cmd = ['tail', '-f', '-n', '0', filename]
+    process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+
+    for line in iter(process.stdout.readline, ''):
+        if line:
+            q.put(line.rstrip())
+
+@app.route('/')
+def index():
+    return render_template_string(HTML_TEMPLATE)
+
+@app.route('/stream')
+def stream():
+    def generate():
+        q = queue.Queue()
+        log_file = '/workspace/logs/comfyui.log'
+
+        # Start tailing in a separate thread
+        thread = threading.Thread(target=tail_file, args=(log_file, q))
+        thread.daemon = True
+        thread.start()
+
+        while True:
+            try:
+                line = q.get(timeout=1)
+                yield f"data: {line}\n\n"
+            except queue.Empty:
+                # Send a heartbeat to keep connection alive
+                yield f"data: \n\n"
+
+    return Response(generate(), mimetype="text/event-stream")
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=3002, debug=False)

--- a/log-viewer/log_streamer.py
+++ b/log-viewer/log_streamer.py
@@ -138,4 +138,4 @@ def stream():
     return Response(generate(), mimetype="text/event-stream")
 
 if __name__ == '__main__':
-    app.run(host='0.0.0.0', port=3002, debug=False)
+    app.run(host='0.0.0.0', port=5002, debug=False)

--- a/log-viewer/start_log_viewer.sh
+++ b/log-viewer/start_log_viewer.sh
@@ -1,3 +1,4 @@
+
 #!/usr/bin/env bash
 
 echo "Starting ComfyUI Log Viewer..."
@@ -11,18 +12,9 @@ if pgrep -f "log_streamer.py" > /dev/null; then
     exit 0
 fi
 
-# Activate ComfyUI venv
-source /workspace/ComfyUI/venv/bin/activate
-
-# Install flask if not already installed
-pip install flask &>/dev/null
-
-# Start the log viewer service (while still in venv)
+# Start the log viewer service using its dedicated venv
 cd /log-viewer
-nohup python3 log_streamer.py > /workspace/logs/log_viewer.log 2>&1 &
+/log-viewer/venv/bin/python log_streamer.py > /workspace/logs/log_viewer.log 2>&1 &
 
 echo "ComfyUI Log Viewer started on port 3002"
 echo "Log file: /workspace/logs/log_viewer.log"
-
-# Note: We don't deactivate here because the process is backgrounded
-# The subprocess will continue to use the venv's Python

--- a/log-viewer/start_log_viewer.sh
+++ b/log-viewer/start_log_viewer.sh
@@ -11,9 +11,18 @@ if pgrep -f "log_streamer.py" > /dev/null; then
     exit 0
 fi
 
-# Start the log viewer service
+# Activate ComfyUI venv
+source /workspace/ComfyUI/venv/bin/activate
+
+# Install flask if not already installed
+pip install flask &>/dev/null
+
+# Start the log viewer service (while still in venv)
 cd /log-viewer
-python3 log_streamer.py > /workspace/logs/log_viewer.log 2>&1 &
+nohup python3 log_streamer.py > /workspace/logs/log_viewer.log 2>&1 &
 
 echo "ComfyUI Log Viewer started on port 3002"
 echo "Log file: /workspace/logs/log_viewer.log"
+
+# Note: We don't deactivate here because the process is backgrounded
+# The subprocess will continue to use the venv's Python

--- a/log-viewer/start_log_viewer.sh
+++ b/log-viewer/start_log_viewer.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+echo "Starting ComfyUI Log Viewer..."
+
+# Create logs directory if it doesn't exist
+mkdir -p /workspace/logs
+
+# Check if already running
+if pgrep -f "log_streamer.py" > /dev/null; then
+    echo "Log viewer is already running"
+    exit 0
+fi
+
+# Start the log viewer service
+cd /log-viewer
+python3 log_streamer.py > /workspace/logs/log_viewer.log 2>&1 &
+
+echo "ComfyUI Log Viewer started on port 3002"
+echo "Log file: /workspace/logs/log_viewer.log"

--- a/log-viewer/stop_log_viewer.sh
+++ b/log-viewer/stop_log_viewer.sh
@@ -3,10 +3,17 @@
 echo "Stopping ComfyUI Log Viewer..."
 
 # Find and kill the log viewer process
-pkill -f "log_streamer.py"
+# Using pkill with the full path to be more specific
+pkill -f "/workspace/ComfyUI/venv/bin/python.*log_streamer.py"
 
 if [ $? -eq 0 ]; then
     echo "Log viewer stopped successfully"
 else
-    echo "Log viewer was not running"
+    # Try again with a broader pattern if the first attempt failed
+    pkill -f "log_streamer.py"
+    if [ $? -eq 0 ]; then
+        echo "Log viewer stopped successfully"
+    else
+        echo "Log viewer was not running"
+    fi
 fi

--- a/log-viewer/stop_log_viewer.sh
+++ b/log-viewer/stop_log_viewer.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+echo "Stopping ComfyUI Log Viewer..."
+
+# Find and kill the log viewer process
+pkill -f "log_streamer.py"
+
+if [ $? -eq 0 ]; then
+    echo "Log viewer stopped successfully"
+else
+    echo "Log viewer was not running"
+fi

--- a/log-viewer/stop_log_viewer.sh
+++ b/log-viewer/stop_log_viewer.sh
@@ -1,19 +1,13 @@
+
 #!/usr/bin/env bash
 
 echo "Stopping ComfyUI Log Viewer..."
 
-# Find and kill the log viewer process
-# Using pkill with the full path to be more specific
-pkill -f "/workspace/ComfyUI/venv/bin/python.*log_streamer.py"
+# Find and kill the log viewer process (now using the venv python)
+pkill -f "/log-viewer/venv/bin/python.*log_streamer.py"
 
 if [ $? -eq 0 ]; then
     echo "Log viewer stopped successfully"
 else
-    # Try again with a broader pattern if the first attempt failed
-    pkill -f "log_streamer.py"
-    if [ $? -eq 0 ]; then
-        echo "Log viewer stopped successfully"
-    else
-        echo "Log viewer was not running"
-    fi
+    echo "Log viewer was not running"
 fi

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -69,7 +69,7 @@ http {
         listen 3002;
 
         location / {
-            proxy_pass http://localhost:3002;
+            proxy_pass http://localhost:5002;
             proxy_http_version 1.1;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -5,12 +5,12 @@ http {
     client_max_body_size 500M;
 
     # Increase proxy timeout from 60s to 600s
-	proxy_connect_timeout 600;
-	proxy_send_timeout    600;
-	proxy_read_timeout    600;
-	send_timeout          600;
+    proxy_connect_timeout 600;
+    proxy_send_timeout    600;
+    proxy_read_timeout    600;
+    send_timeout          600;
 
-    # InvokeAI
+    # ComfyUI
     server {
         listen 3000;
 
@@ -21,9 +21,8 @@ http {
             proxy_set_header Connection "upgrade";
             add_header Cache-Control no-cache;
             proxy_set_header Host $host;
-
-            proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
-	        proxy_set_header   X-Real-IP		$remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Real-IP $remote_addr;
             proxy_pass http://localhost:3001;
         }
 
@@ -34,9 +33,8 @@ http {
             proxy_set_header Connection "upgrade";
             add_header Cache-Control no-cache;
             proxy_set_header Host $host;
-
-            proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
-	        proxy_set_header   X-Real-IP		$remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Real-IP $remote_addr;
             proxy_pass http://localhost:3001;
         }
 
@@ -47,11 +45,9 @@ http {
             proxy_set_header Accept-Encoding gzip;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Host $host;
-
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
-
             proxy_intercept_errors on;
             error_page 502 =200 @502;
         }
@@ -63,9 +59,29 @@ http {
             if_modified_since off;
             expires off;
             etag off;
-
             root /usr/share/nginx/html;
             rewrite ^(.*)$ /502.html break;
+        }
+    }
+
+    # Log Viewer - Separate service
+    server {
+        listen 3002;
+
+        location / {
+            proxy_pass http://localhost:3002;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+
+            # Important for Server-Sent Events
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_read_timeout 86400s;
+            proxy_set_header Connection '';
+            chunked_transfer_encoding off;
         }
     }
 }

--- a/scripts/pre_start.sh
+++ b/scripts/pre_start.sh
@@ -159,3 +159,6 @@ else
 
     /start_comfyui.sh "${ARGS[@]}"
 fi
+
+# Start ComfyUI Log Viewer
+/log-viewer/start_log_viewer.sh


### PR DESCRIPTION
Created a logging service that streams log real-time from ComfyUI.

Change list:
- `log-viewer`: new directory with following
- - `log_streamer.py`: Python mini-server using Flask that streams the logs real-time. Runs on port 5002
- - `start_log_viewer.sh`: Script to begin log service
- - `stop_log_viewer.sh`: Script to stop log service
- `build/install_log_viewer.sh`:  Init script for service. Sets up venv and installs dependencies
- `nginx/nginx.conf`: Random whitespace changes + listen on port 3002 -> redirect to 5002 
- `scripts/pre_start.sh`: Add call to invoke the start-up script

Testing:
- Made local changes to push the following image:
- - `chardough/comfyui:cu128-py312-v0.3.46-char-test-logs` (contains the changes listed above)
- Created template (`ComfyUI with Log Viewer`) which is based off the existing ones, but additionally exposes port 3002
- Launched the pod using this template, and clicked Connect:

<img width="554" height="457" alt="image" src="https://github.com/user-attachments/assets/3415ac50-f70c-4ce2-a10e-6e9beebf5f8a" />

- Verified the initial logs from service:
 
<img width="960" height="857" alt="image" src="https://github.com/user-attachments/assets/dad67af1-59ee-46cd-825c-326dd7a782d8" />

- Ran the default Comfy workflow to generate more logs. Verified that the logs showed up real-time without needing to refresh:
<img width="1253" height="556" alt="image" src="https://github.com/user-attachments/assets/184b8ff0-ee38-47ae-9806-1a41e7b046ed" />